### PR TITLE
Fix flow for authorization controller

### DIFF
--- a/OKSdk/OKSdk/OKSession.h
+++ b/OKSdk/OKSdk/OKSession.h
@@ -45,6 +45,7 @@ extern NSString * const kAPIBaseURL;
 
 - (void)refreshAuthToken;
 
+- (BOOL)canHandleOpenURL:(NSURL*)url;
 - (BOOL)handleOpenURL:(NSURL*)url;
 - (void)close;
 

--- a/OKSdk/OKSdk/OKSession.m
+++ b/OKSdk/OKSdk/OKSession.m
@@ -72,12 +72,19 @@ static OKSession *_activeSession = nil;
     return self;
 }
 
-- (BOOL)handleOpenURL:(NSURL *)url {
-	if (![[url absoluteString] hasPrefix:self.appBaseUrl]) {
-		NSLog(@"wrong prefix = %@, %@", [url absoluteString], self.appBaseUrl);
-		return NO;
-	}
+- (BOOL)canHandleOpenURL:(NSURL *)url {
+    if (![[url absoluteString] hasPrefix:self.appBaseUrl]) {
+        NSLog(@"wrong prefix = %@, %@", [url absoluteString], self.appBaseUrl);
+        return NO;
+    }
+    return YES;
+}
 
+- (BOOL)handleOpenURL:(NSURL *)url {
+    if (![self canHandleOpenURL:url]) {
+        return NO;
+    }
+    
 	NSDictionary *params = [url.query dictionaryByParsingURLQueryPart];
 
 	if ([params valueForKey:@"error"] != nil) {

--- a/OKSdk/OKSdk/UI/OKAuthorizeController.m
+++ b/OKSdk/OKSdk/UI/OKAuthorizeController.m
@@ -75,8 +75,10 @@
     self.request = request;
 
     if ([request.URL.scheme isEqualToString:self.redirectUrlScheme]) {
-        if ([[OKSession activeSession] handleOpenURL:request.URL]) {
-            [self dismissByCancel:NO];
+        if ([[OKSession activeSession] canHandleOpenURL:request.URL]) {
+            [self dismissByCancel:NO completion:^{
+                [[OKSession activeSession] handleOpenURL:request.URL];
+            }];
             return NO;
         }
     }
@@ -114,6 +116,10 @@
 }
 
 - (void)dismissByCancel:(BOOL)byCancel {
+    [self dismissByCancel:byCancel completion:nil];
+}
+
+- (void)dismissByCancel:(BOOL)byCancel completion:(void (^)(void))completion {
     self.finished = YES;
 
     if (self.navigationController.isBeingDismissed)
@@ -124,10 +130,10 @@
             [self.delegate okWillDismissAuthorizeControllerByCancel:byCancel];
         }
 
-        [self.navigationController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+        [self.navigationController.presentingViewController dismissViewControllerAnimated:YES completion:completion];
     } else {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(300 * NSEC_PER_MSEC)), dispatch_get_main_queue(), ^(void) {
-            [self dismissByCancel:byCancel];
+            [self dismissByCancel:byCancel completion:completion];
         });
     }
 }


### PR DESCRIPTION
The controller should be dismissed before access token set because it's
impossible to present another view controller from delegate of
`OKSession`.

For now, modal view controller presentation from `-okDidLogin` fails with the
following warning in console:
```
Warning: Attempt to present <...> on <...> while a presentation is in progress!
```